### PR TITLE
Update to 0.24.0

### DIFF
--- a/0001-Use-Python-3-in-util-scripts.patch
+++ b/0001-Use-Python-3-in-util-scripts.patch
@@ -1,0 +1,33 @@
+From 0f28f2f69329e46c699c40cc57adcd204f176dab Mon Sep 17 00:00:00 2001
+From: Guillaume Poirier-Morency <guillaumepoiriermorency@gmail.com>
+Date: Sat, 21 Mar 2020 11:20:30 -0700
+Subject: [PATCH] Use Python 3 in util scripts
+
+---
+ crawl-ref/source/util/species-gen.py | 2 +-
+ crawl-ref/source/util/txc            | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git crawl-ref/source/util/species-gen.py crawl-ref/source/util/species-gen.py
+index a4b103afc1..ec82da39eb 100755
+--- crawl-ref/source/util/species-gen.py
++++ crawl-ref/source/util/species-gen.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ from __future__ import print_function
+ 
+diff --git crawl-ref/source/util/txc crawl-ref/source/util/txc
+index df4c5a341c..1d396b4467 100755
+--- crawl-ref/source/util/txc
++++ crawl-ref/source/util/txc
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ # -*- coding: utf-8 -*-
+ 
+ import os, re, sys, codecs, difflib
+-- 
+2.26.0.rc2
+

--- a/org.develz.Crawl.json
+++ b/org.develz.Crawl.json
@@ -14,14 +14,19 @@
     ],
     "modules": [
         "shared-modules/glu/glu-9.json",
+        "python3-PyYAML.json",
         {
             "name": "crawl",
             "buildsystem": "autotools",
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://crawl.develz.org/release/0.22/stone_soup-0.22.1.tar.xz",
-                    "sha256": "49834a0fbfcba4953359c649fbe52f42b983f5c0cc5e9aa95c5e4066f1453c40"
+                    "url": "http://crawl.develz.org/release/0.24/stone_soup-0.24.0.tar.xz",
+                    "sha256": "eb069ae421d4246a3332d9081fb6e08b4bfaa71c407ffc17c194c5f9170d7561"
+                },
+                {
+                    "type": "patch",
+                    "path": "0001-Use-Python-3-in-util-scripts.patch"
                 },
                 {
                     "type": "file",

--- a/python3-PyYAML.json
+++ b/python3-PyYAML.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-PyYAML",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} PyYAML"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/64/c2/b80047c7ac2478f9501676c988a5411ed5572f35d1beff9cae07d321512c/PyYAML-5.3.1.tar.gz",
+            "sha256": "b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"
+        }
+    ]
+}


### PR DESCRIPTION
Crawl build relies on the existence of `/usr/bin/env python` since the 0.23 series. We might have to patch the source code for that to work out.