### PR TITLE
allow access to ~/.crawlrc

### DIFF
--- a/org.develz.Crawl.json
+++ b/org.develz.Crawl.json
@@ -10,7 +10,8 @@
         "--socket=wayland",
         "--share=ipc",
         "--device=dri",
-        "--filesystem=~/.crawl:create"
+        "--filesystem=~/.crawl:create",
+        "--filesystem=~/.crawlrc:ro"
     ],
     "modules": [
         "shared-modules/glu/glu-9.json",


### PR DESCRIPTION
No permissions exist to make use of a crawlrc file. This PR adds ~/.crawlrc:ro to the sandbox filesystem permissions.