### PR TITLE
remove unused SDL1 dependencies

### DIFF
--- a/org.develz.Crawl.json
+++ b/org.develz.Crawl.json
@@ -15,9 +15,6 @@
     ],
     "modules": [
         "shared-modules/glu/glu-9.json",
-        "shared-modules/SDL/SDL-1.2.15.json",
-        "shared-modules/SDL/SDL_image-1.2.12.json",
-        "shared-modules/SDL/SDL_mixer-1.2.12.json",
         "shared-modules/lua5.1/lua-5.1.5.json",
         "python3-PyYAML.json",
         {


### PR DESCRIPTION
Crawl has been using SDL2 for a while now, which is included in the SDK.