### PR TITLE
Update to 0.29.1

### DIFF
--- a/org.develz.Crawl.appdata.xml
+++ b/org.develz.Crawl.appdata.xml
@@ -4,11 +4,23 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
   <name>Dungeon Crawl Stone Soup</name>
-  <summary>A roguelike adventure</summary>
+  <summary>Roguelike dungeon exploration game</summary>
+  <developer_name>The Dungeon Crawl Stone Soup Devteam</developer_name>
   <description>
     <p>
-      A roguelike adventure through dungeons filled with dangerous monsters in
-      a quest to find the mystifyingly fabulous Orb of Zot.
+      Crawl is a fun game in the grand tradition of similar games like Rogue,
+      Hack and Moria. The objective is to travel deep into a subterranean cave
+      complex and retrieve the Orb of Zot, guarded by many horrible and hideous
+      creatures.
+    </p>
+    <p>
+      If you have never played Crawl (or a similar game) before, select the
+      tutorial from the starting menu. The tutorial explains the interface in
+      five easy lessons. Once you're familiar with the controls, you may want to
+      play a few games using hints mode.
+    </p>
+    <p>
+      This is the Stone Soup version of Dungeon Crawl.
     </p>
   </description>
   <categories>
@@ -28,6 +40,18 @@
   </screenshots>
   <update_contact>guillaumepoiriermorency@gmail.com</update_contact>
   <releases>
+    <release version="0.29.1" date="2022-09-11">
+      <description>
+        <p>
+          Quick bugfix release after the tournament. CI should now build linux packages as well as mac/win,
+          thanks to #2188. Debian packages here: https://github.com/crawl/crawl/releases/tag/0.29.1-debian
+        </p>
+        <ul>
+          <li>20+ bug and documentation fixes</li>
+          <li>Improvements to linux packaging support infrastructure</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.29.0" date="2022-08-25">
       <description>
         <p>

--- a/org.develz.Crawl.appdata.xml
+++ b/org.develz.Crawl.appdata.xml
@@ -43,8 +43,7 @@
     <release version="0.29.1" date="2022-09-11">
       <description>
         <p>
-          Quick bugfix release after the tournament. CI should now build linux packages as well as mac/win,
-          thanks to #2188. Debian packages here: https://github.com/crawl/crawl/releases/tag/0.29.1-debian
+          Quick bugfix release after the tournament.
         </p>
         <ul>
           <li>20+ bug and documentation fixes</li>

--- a/org.develz.Crawl.json
+++ b/org.develz.Crawl.json
@@ -23,8 +23,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/crawl/crawl/releases/download/0.29.0/stone_soup-0.29.0-nodeps.tar.xz",
-                    "sha256": "b013f9b3bbee1f9e2113c20130a52097dbd9e83ce8e1060438bd3e83829fa9c4"
+                    "url": "https://github.com/crawl/crawl/releases/download/0.29.1-debian/crawl_0.29.1.orig.tar.xz",
+                    "sha256": "b5032c96f27de202bf24e11361b8cf4509839821916804978892df1f29f95bd3"
                 },
                 {
                     "type": "file",
@@ -46,16 +46,14 @@
                 "DATADIR=share/crawl",
                 "SAVEDIR=~/.crawl",
                 "EXTERNAL_LDFLAGS=-L/app/lib",
-                "TILES=y"
+                "TILES=y",
+                "XDG_NAME=org.develz.Crawl",
+                "install-xdg-data"
             ],
             "post-install": [
+                "rm -rf /app/share/metainfo",
                 "install -D org.develz.Crawl.appdata.xml /app/share/appdata/org.develz.Crawl.appdata.xml",
-                "desktop-file-edit --set-key Name --set-value 'Dungeon Crawl Stone Soup' --set-key Exec --set-value /app/bin/crawl --set-key Icon --set-value org.develz.Crawl debian/crawl-tiles.desktop",
-                "install -D debian/crawl-tiles.desktop /app/share/applications/org.develz.Crawl.desktop",
-                "install -D dat/tiles/stone_soup_icon-32x32.png /app/share/icons/hicolor/32x32/apps/org.develz.Crawl.png",
-                "install -D dat/tiles/stone_soup_icon-48x48.png /app/share/icons/hicolor/48x48/apps/org.develz.Crawl.png",
-                "install -D dat/tiles/stone_soup_icon-512x512.png /app/share/icons/hicolor/512x512/apps/org.develz.Crawl.png",
-                "install -D dat/tiles/stone_soup_icon.svg /app/share/icons/hicolor/scalable/apps/org.develz.Crawl.svg"
+                "sed -i 's/ (.*)//g' /app/share/applications/org.develz.Crawl.desktop"
             ]
         }
     ]


### PR DESCRIPTION
Desktop files, icons and appdata are provided by the new build target install-xdg-data.

Closes #19 