### PR TITLE
Use X11 in fallback mode

### DIFF
--- a/org.develz.Crawl.json
+++ b/org.develz.Crawl.json
@@ -5,7 +5,7 @@
     "sdk": "org.freedesktop.Sdk",
     "command": "crawl",
     "finish-args": [
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--socket=wayland",
         "--share=ipc",


### PR DESCRIPTION
Wayland is already the default right now for SDL2, so we can enforce a safer behaviour by default.