### PR TITLE
Use a cache dir per version

### DIFF
--- a/org.develz.Crawl.json
+++ b/org.develz.Crawl.json
@@ -39,6 +39,7 @@
                 "DATADIR=share/crawl",
                 "SAVEDIR=~/.crawl",
                 "EXTERNAL_LDFLAGS=-L/app/lib",
+                "EXTERNAL_DEFINES=-DVERSIONED_CACHE_DIR",
                 "TILES=y"
             ],
             "make-install-args": [
@@ -46,6 +47,7 @@
                 "DATADIR=share/crawl",
                 "SAVEDIR=~/.crawl",
                 "EXTERNAL_LDFLAGS=-L/app/lib",
+                "EXTERNAL_DEFINES=-DVERSIONED_CACHE_DIR",
                 "TILES=y",
                 "XDG_NAME=org.develz.Crawl",
                 "install-xdg-data"


### PR DESCRIPTION
The shared cache directory makes use of mtime to detect cache that must be invalidated and it is not working properly under Flatpak's sandboxing.