### PR TITLE
Update to 0.32.1.

### DIFF
--- a/org.develz.Crawl.appdata.xml
+++ b/org.develz.Crawl.appdata.xml
@@ -42,6 +42,17 @@
   </screenshots>
   <update_contact>guillaumepoiriermorency@gmail.com</update_contact>
   <releases>
+    <release version="0.32.1" date="2024-09-25">
+      <description>
+        <p>
+          Bugfix release.
+        </p>
+        <ul>
+          <li>Fix blockable beam attacks from monster spells being blocked 100% of the time.</li>
+          <li>40 other bug fixes, interface improvements, and documentation updates.</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.32.0" date="2024-08-29">
       <description>
         <p>

--- a/org.develz.Crawl.json
+++ b/org.develz.Crawl.json
@@ -23,8 +23,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/crawl/crawl/releases/download/0.32.0/stone_soup-0.32.0-nodeps.tar.xz",
-                    "sha256": "b49340057d3d62a5906fcd4f037a299de9a500e7b7c7541f77dfc1863fbe7d56"
+                    "url": "https://github.com/crawl/crawl/releases/download/0.32.1/stone_soup-0.32.1-nodeps.tar.xz",
+                    "sha256": "e4ec6072088c73f4233634629654395b05e7886199186be6d3f8c95fa3451fc7"
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
Dungeon Crawl: Stone Soup 0.32.1.

Just a bugfix release: https://github.com/crawl/crawl/releases/tag/0.32.1